### PR TITLE
2.6.3 backupify unicode recover

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 gem "tlsmail", "~> 0.0.1" if RUBY_VERSION <= "1.8.6"
 gem "jruby-openssl", :platforms => :jruby
 
+gem 'charlock_holmes'
+
 group :development, :test do
   gem "appraisal", "~> 1.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "tlsmail", "~> 0.0.1" if RUBY_VERSION <= "1.8.6"
 gem "jruby-openssl", :platforms => :jruby
 
-gem 'charlock_holmes', '0.7.3'
+gem 'charlock_holmes'
 
 group :development, :test do
   gem "appraisal", "~> 1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "tlsmail", "~> 0.0.1" if RUBY_VERSION <= "1.8.6"
 gem "jruby-openssl", :platforms => :jruby
 
-gem 'charlock_holmes'
+gem 'charlock_holmes', '0.7.3'
 
 group :development, :test do
   gem "appraisal", "~> 1.0"

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -224,7 +224,7 @@ module Mail
     def process_unsafe_string(raw_field)
       detection_obj = self.class.detector.detect(raw_field)
 
-      encoding = detection_obj.nil? ? detection_obj[:encoding] : Encoding::UTF_8
+      encoding = !detection_obj.nil? ? detection_obj[:encoding] : Encoding::UTF_8
 
       double_encode(raw_field.force_encoding(encoding), invalid: :replace, undef: :replace, replace: '_')
     end

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -234,8 +234,8 @@ module Mail
 
       header_parts = raw_field.split('filename=')
       filename = header_parts[1]
-      filename = process_unsafe_string(filename).strip[1..-2]
-      [header_parts.first, "filename*=", Mail::Encodings.param_encode(filename),].encode!(Encoding::ASCII)
+      filename = process_unsafe_string(filename).gsub(/(^"|"$)/, '')
+      [header_parts.first, "filename*=", Mail::Encodings.param_encode(filename),].join.encode!(Encoding::ASCII)
       # [header_parts[0], "filename*=UTF-8''", ERB::Util.url_encode(filename),].join.encode!(Encoding::ASCII)
     end
 

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -237,7 +237,7 @@ module Mail
       header_parts = raw_field.split('filename=')
       filename = header_parts[1]
       filename = unquote(process_unsafe_string(filename))
-      [header_parts.first, "filename*=", dquote(Mail::Encodings.param_encode(filename)),].join.encode!(Encoding::ASCII)
+      [header_parts.first, "filename*=", Mail::Encodings.param_encode(filename),].join.encode!(Encoding::ASCII)
     end
 
     def process_content_type(raw_field)

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -1,4 +1,5 @@
 require 'mail/fields'
+require 'charlock_holmes'
 
 # encoding: utf-8
 module Mail
@@ -221,7 +222,9 @@ module Mail
     end
 
     def process_unsafe_string(raw_field)
-      encoding = self.class.detector.detect(raw_field).try(:[], :encoding) || Encoding::UTF_8
+      detection_obj = self.class.detector.detect(raw_field)
+
+      encoding = detection_obj.nil? ? detection_obj[:encoding] : Encoding::UTF_8
 
       double_encode(raw_field.force_encoding(encoding), invalid: :replace, undef: :replace, replace: '_')
     end

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -202,7 +202,84 @@ module Mail
 
     private
 
+    def self.detector
+      @char_detector ||= CharlockHolmes::EncodingDetector.new
+    end
+
+    # If the string is already of the same encoding, no encoding will take place; double-encoding forces a conversion
+    def double_encode(str, opts = {})
+      str.encode(Encoding::UTF_16LE, opts).encode(Encoding::UTF_8, opts)
+    end
+
+    def string_is_valid?(str)
+      begin
+        double_encode(str)
+        true
+      rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError => e
+        false
+      end
+    end
+
+    def process_unsafe_string(raw_field)
+      encoding = self.class.detector.detect(raw_field).try(:[], :encoding) || Encoding::UTF_8
+
+      double_encode(raw_field.force_encoding(encoding), invalid: :replace, undef: :replace, replace: '_')
+    end
+
+    def process_content_disposition(raw_field)
+      return raw_field unless raw_field.start_with?('Content-Disposition') && raw_field.include?('filename=')
+
+      # Might want to check ascii_only?
+      return raw_field if string_is_valid?(raw_field)
+
+      header_parts = raw_field.split('filename=')
+      filename = header_parts[1]
+      filename = process_unsafe_string(filename).strip[1..-2]
+      [header_parts.first, "filename*=", Mail::Encodings.param_encode(filename),].encode!(Encoding::ASCII)
+      # [header_parts[0], "filename*=UTF-8''", ERB::Util.url_encode(filename),].join.encode!(Encoding::ASCII)
+    end
+
+    # def get_utf8_hex_safe_char(ch)
+    #   if ch.ascii_only?
+    #     ch
+    #   else
+    #     ch.bytes.map { |s| '=' << s.to_s(16) }.join
+    #   end
+    # end
+
+    def process_content_type(raw_field)
+      return raw_field unless raw_field.start_with?('Content-Type') && raw_field.include?('name=')
+
+      return raw_field if string_is_valid?(raw_field)
+
+      header_parts = raw_field.split(';').map { |s| s.strip }
+
+      header_parts.each_with_index do |part, idx|
+        next unless part.start_with?('name')
+
+        raw_filename = part.sub(/^\s*name=\s*/, '')
+
+        filename = process_unsafe_string(raw_filename)
+
+        header_parts[idx] = "filename=\"#{Mail::Encodings.q_value_encode(filename)}"
+
+        binding.pry
+
+        # encoded = filename.chars.map { |c| get_utf8_hex_safe_char(c) }.join
+        #
+        # # Are we supposed to put a newline before the =?UTF-8? at the end?
+        # header_parts[idx] = "name=\"=?UTF-8?Q?#{encoded}.?==?UTF-8?Q?txt?="
+      end
+
+
+      header_parts.join('; ')
+    end
+
     def split(raw_field)
+      raw_field = process_content_disposition(raw_field)
+
+      raw_field = process_content_type(raw_field)
+
       match_data = raw_field.mb_chars.match(FIELD_SPLIT)
       [match_data[1].to_s.mb_chars.strip, match_data[2].to_s.mb_chars.strip.to_s]
     rescue

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -298,7 +298,7 @@ module Mail
 
         filename = process_unsafe_string(unquoted)
 
-        encoded_filename = dquote(Mail::Encodings.b_value_encode(filename))
+        encoded_filename = dquote(Mail::Encodings.decode_encode(filename, :encode))
 
         header_parts[idx] = "#{key}=#{encoded_filename}"
       end

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -261,7 +261,9 @@ module Mail
 
         filename = process_unsafe_string(raw_filename)
 
-        header_parts[idx] = "filename=\"#{Mail::Encodings.q_value_encode(filename)}"
+        encoded_filename = Mail::Encodings.b_value_encode(filename)
+
+        header_parts[idx] = "name=\"#{encoded_filename}\""
 
         binding.pry
 
@@ -270,7 +272,6 @@ module Mail
         # # Are we supposed to put a newline before the =?UTF-8? at the end?
         # header_parts[idx] = "name=\"=?UTF-8?Q?#{encoded}.?==?UTF-8?Q?txt?="
       end
-
 
       header_parts.join('; ')
     end

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -236,8 +236,8 @@ module Mail
 
       header_parts = raw_field.split('filename=')
       filename = header_parts[1]
-      filename = process_unsafe_string(filename).gsub(/(^"|"$)/, '')
-      [header_parts.first, "filename*=", Mail::Encodings.param_encode(filename),].join.encode!(Encoding::ASCII)
+      filename = unquote(process_unsafe_string(filename))
+      [header_parts.first, "filename*=", dquote(Mail::Encodings.param_encode(filename)),].join.encode!(Encoding::ASCII)
     end
 
     def process_content_type(raw_field)
@@ -254,11 +254,13 @@ module Mail
 
         raw_filename = part.sub(/^\s*(file)?name\s*=\s*/, '')
 
-        filename = process_unsafe_string(raw_filename).gsub(/(^"|"$)/, '')
+        unquoted = unquote(raw_filename)
 
-        encoded_filename = Mail::Encodings.b_value_encode(filename)
+        filename = process_unsafe_string(unquoted)
 
-        header_parts[idx] = "#{key}=\"#{encoded_filename}\""
+        encoded_filename = dquote(Mail::Encodings.b_value_encode(filename))
+
+        header_parts[idx] = "#{key}=#{encoded_filename}"
       end
 
       header_parts.join('; ')

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -228,15 +228,13 @@ module Mail
 
     def process_content_disposition(raw_field)
       return raw_field unless raw_field.start_with?('Content-Disposition') && raw_field.include?('filename=')
-
-      # Might want to check ascii_only?
+      
       return raw_field if string_is_valid?(raw_field)
 
       header_parts = raw_field.split('filename=')
       filename = header_parts[1]
       filename = process_unsafe_string(filename).gsub(/(^"|"$)/, '')
       [header_parts.first, "filename*=", Mail::Encodings.param_encode(filename),].join.encode!(Encoding::ASCII)
-      # [header_parts[0], "filename*=UTF-8''", ERB::Util.url_encode(filename),].join.encode!(Encoding::ASCII)
     end
 
     def process_content_type(raw_field)

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -285,7 +285,9 @@ module Mail
 
         unquoted = unquote(raw_filename)
 
-        encoded = Mail::Encodings.param_encode(unquoted)
+        corrected = process_unsafe_string(unquoted)
+
+        encoded = Mail::Encodings.param_encode(corrected)
 
         header_parts[idx] = "filename*=#{encoded}"
       end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2118,6 +2118,7 @@ module Mail
 
     # Returns the filename of the attachment (if it exists) or returns nil
     def find_attachment
+      binding.pry
       content_type_name = header[:content_type].filename rescue nil
       content_disp_name = header[:content_disposition].filename rescue nil
       content_loc_name  = header[:content_location].location rescue nil

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2118,7 +2118,6 @@ module Mail
 
     # Returns the filename of the attachment (if it exists) or returns nil
     def find_attachment
-      binding.pry
       content_type_name = header[:content_type].filename rescue nil
       content_disp_name = header[:content_disposition].filename rescue nil
       content_loc_name  = header[:content_location].location rescue nil

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
   s.add_dependency('mime-types', [">= 1.16", "< 3"])
+  s.add_dependency('charlock_holmes', '>= 0.7.3')
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')

--- a/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_shift_jis.eml
+++ b/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_shift_jis.eml
@@ -24,7 +24,7 @@ Content-Type: text/plain; charset=UTF-8;
  filename="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment;
-filename="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt"
+ filename="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt"
 
 44OG44K544OI
 --------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_shift_jis.eml
+++ b/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_shift_jis.eml
@@ -1,0 +1,30 @@
+Subject: Test message
+References: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+To: luser@datto.com
+From: "A. User" <auser@datto.com>
+X-Forwarded-Message-Id: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+Message-ID: <04e4c41f-c77a-a688-8a95-3159eb30954b@datto.com>
+Date: Thu, 11 Aug 2016 11:41:56 -0400
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0)
+ Gecko/20100101 Thunderbird/45.2.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------BE748925EE50C6B7F60FFA05"
+
+This is a multi-part message in MIME format.
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+Just a test.
+
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=UTF-8;
+ name="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt";
+ filename="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+filename="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt"
+
+44OG44K544OI
+--------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_shift_jis_disposition_only.eml
+++ b/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_shift_jis_disposition_only.eml
@@ -1,0 +1,28 @@
+Subject: Test message
+References: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+To: luser@datto.com
+From: "A. User" <auser@datto.com>
+X-Forwarded-Message-Id: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+Message-ID: <04e4c41f-c77a-a688-8a95-3159eb30954b@datto.com>
+Date: Thu, 11 Aug 2016 11:41:56 -0400
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0)
+ Gecko/20100101 Thunderbird/45.2.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------BE748925EE50C6B7F60FFA05"
+
+This is a multi-part message in MIME format.
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+Just a test.
+
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=UTF-8;
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="‚Æ‚ñ‚Å‚à‚È‚¢‚·‚®‚±’·‚¢•¶Žš—ñ.txt"
+
+44OG44K544OI
+--------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_utf8.eml
+++ b/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_utf8.eml
@@ -24,7 +24,7 @@ Content-Type: text/plain; charset=UTF-8;
  filename="とんでもないすぐこ長い文字列.txt"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment;
-filename="とんでもないすぐこ長い文字列.txt"
+ filename="とんでもないすぐこ長い文字列.txt"
 
 44OG44K544OI
 --------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_utf8.eml
+++ b/spec/fixtures/emails/attachment_emails/invalid_attachment_filename_encoding_utf8.eml
@@ -1,0 +1,30 @@
+Subject: Test message
+References: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+To: luser@datto.com
+From: "A. User" <auser@datto.com>
+X-Forwarded-Message-Id: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+Message-ID: <04e4c41f-c77a-a688-8a95-3159eb30954b@datto.com>
+Date: Thu, 11 Aug 2016 11:41:56 -0400
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0)
+ Gecko/20100101 Thunderbird/45.2.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------BE748925EE50C6B7F60FFA05"
+
+This is a multi-part message in MIME format.
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+Just a test.
+
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=UTF-8;
+ name="とんでもないすぐこ長い文字列.txt";
+ filename="とんでもないすぐこ長い文字列.txt"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+filename="とんでもないすぐこ長い文字列.txt"
+
+44OG44K544OI
+--------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
+++ b/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
@@ -1,0 +1,30 @@
+Subject: Test message
+References: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+To: luser@datto.com
+From: "A. User" <auser@datto.com>
+X-Forwarded-Message-Id: <e4f19658-7af0-5137-682c-fb7ea8b71d1b@datto.com>
+Message-ID: <04e4c41f-c77a-a688-8a95-3159eb30954b@datto.com>
+Date: Thu, 11 Aug 2016 11:41:56 -0400
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0)
+ Gecko/20100101 Thunderbird/45.2.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------BE748925EE50C6B7F60FFA05"
+
+This is a multi-part message in MIME format.
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+Just a test.
+
+--------------BE748925EE50C6B7F60FFA05
+Content-Type: text/plain; charset=UTF-8;
+ name="意地悪 sample = filename= name= \"file\".txt";
+ filename="意地悪 sample = filename= name= \"file\".txt"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+filename="意地悪 sample = filename= name= \"file\".txt"
+
+44OG44K544OI
+--------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
+++ b/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
@@ -20,11 +20,11 @@ Just a test.
 
 --------------BE748925EE50C6B7F60FFA05
 Content-Type: text/plain; charset=UTF-8;
- name="意地悪 sample = filename= name= \"file\".txt";
- filename="意地悪 sample = filename= name= \"file\".txt"
+ name="意地悪 sample; = filename= name= \"file\" 笑.txt";
+ filename="意地悪 sample; = filename= name= \"file\" 笑.txt"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment;
-filename="意地悪 sample = filename= name= \"file\".txt"
+filename="意地悪 sample; = filename= name= \"file\" 笑.txt"
 
 44OG44K544OI
 --------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
+++ b/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
@@ -20,11 +20,11 @@ Just a test.
 
 --------------BE748925EE50C6B7F60FFA05
 Content-Type: text/plain; charset=UTF-8;
- name="意地悪 sample; = filename= name= \"file\" 笑.txt";
- filename="意地悪 sample; = filename= name= \"file\" 笑.txt"
+ name="意地悪 sample; = filename= name= \"file\" zzzz笑.txt";
+ filename="意地悪 sample; = filename= name= \"file\" zzzz笑.txt"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment;
-filename="意地悪 sample; = filename= name= \"file\" 笑.txt"
+filename="意地悪 sample; = filename= name= \"file\" zzzz笑.txt"
 
 44OG44K544OI
 --------------BE748925EE50C6B7F60FFA05--

--- a/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
+++ b/spec/fixtures/emails/attachment_emails/utf8_filename_with_control_characters.eml
@@ -24,7 +24,7 @@ Content-Type: text/plain; charset=UTF-8;
  filename="意地悪 sample; = filename= name= \"file\" zzzz笑.txt"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment;
-filename="意地悪 sample; = filename= name= \"file\" zzzz笑.txt"
+ filename="意地悪 sample; = filename= name= \"file\" zzzz笑.txt"
 
 44OG44K544OI
 --------------BE748925EE50C6B7F60FFA05--

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -236,7 +236,7 @@ describe "reading emails with attachments" do
 
     it "should not get tripped up on filenames containing control characters" do
       msg = Mail.read(fixture('emails', 'attachment_emails', 'utf8_filename_with_control_characters.eml'))
-      expect(msg.attachments.first.filename).to eq '意地悪 sample; = filename= name= "file" 笑.txt'
+      expect(msg.attachments.first.filename).to eq '意地悪 sample; = filename= name= "file" zzzz笑.txt'
     end
   end
 

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -234,6 +234,12 @@ describe "reading emails with attachments" do
       expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
     end
 
+    it 'should be able to read a Shift-JIS filename from Content-Disposition' do
+      msg = Mail.read(fixture('emails', 'attachment_emails',
+                              'invalid_attachment_filename_encoding_shift_jis_disposition_only.eml'))
+      expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
+    end
+
     it "should not get tripped up on filenames containing control characters" do
       msg = Mail.read(fixture('emails', 'attachment_emails', 'utf8_filename_with_control_characters.eml'))
       expect(msg.attachments.first.filename).to eq '意地悪 sample; = filename= name= "file" zzzz笑.txt'

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -233,6 +233,11 @@ describe "reading emails with attachments" do
       msg = Mail.read(fixture('emails', 'attachment_emails', 'invalid_attachment_filename_encoding_shift_jis.eml'))
       expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
     end
+
+    it "should not get tripped up on filenames containing control characters" do
+      msg = Mail.read(fixture('emails', 'attachment_emails', 'utf8_filename_with_control_characters.eml'))
+      expect(msg.attachments.first.filename).to eq '意地悪 sample = filename= name= "file".txt'
+    end
   end
 
   describe "test emails" do

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -236,7 +236,7 @@ describe "reading emails with attachments" do
 
     it "should not get tripped up on filenames containing control characters" do
       msg = Mail.read(fixture('emails', 'attachment_emails', 'utf8_filename_with_control_characters.eml'))
-      expect(msg.attachments.first.filename).to eq '意地悪 sample = filename= name= "file".txt'
+      expect(msg.attachments.first.filename).to eq '意地悪 sample; = filename= name= "file" 笑.txt'
     end
   end
 

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -222,6 +222,19 @@ describe "Attachments" do
 end
 
 describe "reading emails with attachments" do
+
+  describe "attachments with filenames with invalid encodings" do
+    it "should be able to read the filename of an attachment with improperly included UTF-8 chars" do
+      msg = Mail.read(fixture('emails', 'attachment_emails', 'invalid_attachment_filename_encoding_utf8.eml'))
+      expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
+    end
+
+    it "should be able to read the filename of an attachment with improperly included Shift-JIS chars" do
+      msg = Mail.read(fixture('emails', 'attachment_emails', 'invalid_attachment_filename_encoding_shift_jis.eml'))
+      expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
+    end
+  end
+
   describe "test emails" do
 
     it "should find the attachment using content location" do


### PR DESCRIPTION
# Description of Change

Mail headers are only supposed to include ASCII characters, but some ill-behaved clients insert filenames with non-ASCII characters in these headers.  What's more, they will insert these filenames in whatever encoding they exist in on the user's file system.  Currently, the mail gem simply does not handle these, which is causing an error when using it back up e-mails.

This PR attempts to recover from this scenario by catching it, passing the filename to CharlockHolmes to detect the encoding, converting that string to UTF-8, and then encoding the header as it should have originally been encoded.  Note that, since this is subject to the accuracy of CharlockHolmes' detection and many strings are valid in multiple encodings, there is a nonzero chance of filenames being interpreted as the wrong encoding, especially if they are short.  However, this is still an improvement over the current situation and will no longer cause the app to raise an exception and fail to back up.
## Product Impact

Backups previously failing due to this issue will go through again.
## Deployment Plan

Will need to update app to use new version of gem
## Dependencies and Future Changes

BFY-829
