### PR TITLE
[BFY-1148] Unrecognized encoding fix

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -266,7 +266,14 @@ module Mail
 
       encoding = !detection_obj.nil? ? detection_obj[:encoding] : Encoding::UTF_8
 
-      double_encode(raw_field.force_encoding(encoding), invalid: :replace, undef: :replace, replace: '_')
+      begin
+        raw_field.force_encoding(encoding)
+      rescue ArgumentError
+        # Ruby doesn't recognize the detector's suggestion.
+        raw_field.force_encoding(Encoding::UTF_8)
+      end
+
+      double_encode(raw_field, invalid: :replace, undef: :replace, replace: '_')
     end
 
     def process_content_disposition(raw_field)

--- a/lib/mail/version.rb
+++ b/lib/mail/version.rb
@@ -4,9 +4,9 @@ module Mail
     MAJOR = 2
     MINOR = 6
     PATCH = 3
-    BUILD = nil
+    BFY_PATCH = 2
 
-    STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
+    STRING = [MAJOR, MINOR, PATCH, BFY_PATCH].compact.join('.')
 
     def self.version
       STRING

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -229,6 +229,7 @@ describe "reading emails with attachments" do
       expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
     end
 
+
     it "should be able to read the filename of an attachment with improperly included Shift-JIS chars" do
       msg = Mail.read(fixture('emails', 'attachment_emails', 'invalid_attachment_filename_encoding_shift_jis.eml'))
       expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
@@ -243,6 +244,12 @@ describe "reading emails with attachments" do
     it "should not get tripped up on filenames containing control characters" do
       msg = Mail.read(fixture('emails', 'attachment_emails', 'utf8_filename_with_control_characters.eml'))
       expect(msg.attachments.first.filename).to eq '意地悪 sample; = filename= name= "file" zzzz笑.txt'
+    end
+
+    it "should assume encoding is UTF-8 if the detector's suggestion is not recognized as a valid encoding" do
+      allow(Mail::Field.detector).to receive(:detect).and_return({ encoding: 'some bogus encoding' })
+      msg = Mail.read(fixture('emails', 'attachment_emails', 'invalid_attachment_filename_encoding_utf8.eml'))
+      expect(msg.attachments.first.filename).to eq 'とんでもないすぐこ長い文字列.txt'
     end
   end
 


### PR DESCRIPTION
# Description of Change

It's possible for CharlockHolmes to return an encoding Ruby doesn't know about.  Instead of failing, we'll now fall back to UTF-8 if this happens.
## Product Impact

Further reduce backup failures.
## Deployment Plan

Merge change, tag, create new PR to update pkg reference in BFY app
## Dependencies and Future Changes
#4 BFY-829 (especially BFY-1148)
